### PR TITLE
Update mywebapi service to navigate to api/values on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/samples/dotnetcore/getting-started/mywebapi/.vscode/launch.json
+++ b/samples/dotnetcore/getting-started/mywebapi/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.2/mywebapi.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}/api/values",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}/api/values"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/samples/dotnetcore/getting-started/mywebapi/.vscode/tasks.json
+++ b/samples/dotnetcore/getting-started/mywebapi/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/mywebapi.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/mywebapi.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/mywebapi.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        }
+    ]
+}

--- a/samples/dotnetcore/getting-started/mywebapi/Properties/launchSettings.json
+++ b/samples/dotnetcore/getting-started/mywebapi/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:62732/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "mywebapi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:62733/"
+    }
+  }
+}


### PR DESCRIPTION
Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/823410

When debugging mywebapi service sample, by default the browser opens the page corresponding to the root (http://localhost:123), which in the case of this service returns nothing. This PR sets "/api/values" as the URL to launch.

For Visual Studio:
* The launchSettings.json file is as generated by Visual Studio, except for the "launchUrl" field.
* When Azure Dev Spaces will be initialized for this service, it will automatically reuse the "/api/values" launch URL defined.
* The launchSettings.json file was previously ignored from git, which isn't needed anymore. Please see this PR for more details: https://github.com/github/gitignore/pull/2705/commits/c26008c00dac481a1f780751d6d005d52fd15b83

For Visual Studio Code:
* The launch.json and task.json files are as generated by the official C# for Visual Studio Code extension, except for the "launchBrowser" object.
* Feel free to have a look at the schema definition in the C# extension codebase for more details about the "launchBrowser" object: https://github.com/OmniSharp/omnisharp-vscode/blob/b2581f68d8f754287640ec2050e1ada53a5594e6/src/tools/OptionsSchema.json
* Azure Dev Spaces won't automatically launch the browser, because it's not how it's configured for now. It would make sense to be consistent with the default Visual Studio experience and navigate on launch. Starting a thread about this.