### PR TITLE
Reorder requirements to respect components dependencies

### DIFF
--- a/samples/BikeSharingApp/charts/requirements.yaml
+++ b/samples/BikeSharingApp/charts/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+  - name: databases
+    version: 0.1.0
+    repository: "file://../Databases/charts/databases"
   - name: bikes
     version: 0.1.0
     repository: "file://../Bikes/charts/bikes"
@@ -8,15 +11,9 @@ dependencies:
   - name: billing
     version: 0.1.0
     repository: "file://../Billing/charts/billing"
-  - name: databases
-    version: 0.1.0
-    repository: "file://../Databases/charts/databases"
   - name: gateway
     version: 0.1.0
     repository: "file://../Gateway/charts/gateway"
-  - name: populatedatabase
-    version: 0.1.0
-    repository: "file://../PopulateDatabase/charts/populatedatabase"
   - name: reservation
     version: 0.1.0
     repository: "file://../Reservation/charts/reservation"
@@ -26,3 +23,6 @@ dependencies:
   - name: users
     version: 0.1.0
     repository: "file://../Users/charts/users"
+  - name: populatedatabase
+    version: 0.1.0
+    repository: "file://../PopulateDatabase/charts/populatedatabase"


### PR DESCRIPTION
The failure we saw when installing the helm chart for the first time seemed to be due to some dependencies failing. I looked at all Helm documentation I could find, but didn't find a better way to enforce dependencies that reordering them.