### PR TITLE
Fix samples charts not installable in Helm v2.14.0

### DIFF
--- a/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/deployment.yaml
+++ b/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "bikesharingweb.name" . }}
     chart: {{ template "bikesharingweb.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "bikesharingweb.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/Bikes/charts/bikes/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Bikes/charts/bikes/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "bikes.name" . }}
     chart: {{ template "bikes.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "bikes.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/Billing/charts/billing/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Billing/charts/billing/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "billing.name" . }}
     chart: {{ template "billing.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "billing.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/Gateway/charts/gateway/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Gateway/charts/gateway/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "gateway.name" . }}
     chart: {{ template "gateway.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "gateway.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/Reservation/charts/reservation/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Reservation/charts/reservation/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "reservation.name" . }}
     chart: {{ template "reservation.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "reservation.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/deployment.yaml
+++ b/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "reservationengine.name" . }}
     chart: {{ template "reservationengine.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "reservationengine.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/samples/BikeSharingApp/Users/charts/users/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Users/charts/users/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "users.name" . }}
     chart: {{ template "users.chart" . }}
-    draft: {{ default "draft-app" .Values.draft }}
+    draft: {{ .Values.draft | default "draft-app" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -18,10 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "users.name" . }}
-        draft: {{ default "draft-app" .Values.draft }}
+        draft: {{ .Values.draft | default "draft-app" }}
         release: {{ .Release.Name }}
       annotations:
-        buildID: {{ .Values.buildID }}
+        buildID: {{ .Values.buildID | default "" | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
The root cause of the issue was the previous buildID: {{ .Values.buildID }} definition.
Because this buildId was actually not defined in values.yaml, Helm was interpreting its value as nil, which didn't pass the validation of the new Helm version (2.14.0).
The fix is to make it default explicitly to "", and force the generating YAML string to include quotes (because without quotes, Helm would interpret it as nil, and you get the rest of the story).
I also updated the draft so that we remain consistent. This change (moving to Helm pipelines) doesn't change anything from a behavior perspective.