### PR TITLE
Update the custom GitHub action for azure/docker-login reference in bikes.yml & bikesharing.yml

### DIFF
--- a/.github/workflows/bikes.yml
+++ b/.github/workflows/bikes.yml
@@ -14,7 +14,7 @@ jobs:
     
     - uses: actions/checkout@master
     
-    - uses: azure/container-actions/docker-login@master
+    - uses: azure/docker-login@releases/v1
       with:
         login-server: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/bikesharing.yml
+++ b/.github/workflows/bikesharing.yml
@@ -15,7 +15,7 @@ jobs:
     
     - uses: actions/checkout@master
     
-    - uses: azure/container-actions/docker-login@master
+    - uses: azure/docker-login@releases/v1
       with:
         login-server: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
Update the custom GitHub action for azure/docker-login reference in the bikes.yml since the original custom GitHub action has be deprecated per https://github.com/Azure/container-actions/blob/master/docker-login/action.yml