### PR TITLE
Use Web SDK for ReservationEngine Bike Sharing sample

### DIFF
--- a/samples/BikeSharingApp/Gateway/app.csproj
+++ b/samples/BikeSharingApp/Gateway/app.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Kubernetes.Tools.Targets" Version="1.1.0" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/BikeSharingApp/ReservationEngine/app.csproj
+++ b/samples/BikeSharingApp/ReservationEngine/app.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
* Update the ReservationEngine project in the Bike Sharing sample to use the Microsoft.NET.Sdk.Web project SDK instead of Microsoft.NET.Sdk in order to support launching the browser on F5.
* Added the Microsoft.VisualStudio.Azure.Kubernetes.Tools.Targets package to enable VS tooling support.